### PR TITLE
Functions for changing cursor input mode

### DIFF
--- a/input.scm
+++ b/input.scm
@@ -21,7 +21,10 @@
         scroll-callback
         get-cursor-position
         set-cursor-position
-        get-cursor-world-position)
+        get-cursor-world-position
+        hide-cursor
+        show-cursor
+        disable-cursor)
 
 (define-record-type binding
   %make-binding

--- a/input.scm
+++ b/input.scm
@@ -197,3 +197,12 @@
       (m*vector! ivp near)
       (m*vector! ivp far)
       (values near far))))
+
+(define (hide-cursor)
+  (%set-input-mode (%window) %+cursor+ %+cursor-hidden+))
+
+(define (show-cursor)
+  (%set-input-mode (%window) %+cursor+ %+cursor-normal+))
+
+(define (disable-cursor)
+  (%set-input-mode (%window) %+cursor+ %+cursor-disabled+))


### PR DESCRIPTION
Added the functions hide-cursor, show-cursor, and disable-cursor for changing the cursor input mode, since the capability to do so seemed to be missing. 